### PR TITLE
Increase the pod replica for every service by 3.

### DIFF
--- a/helm/confixa-argocd/values.yaml
+++ b/helm/confixa-argocd/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: argoproj/argocd

--- a/helm/confixa-redis/values.yaml
+++ b/helm/confixa-redis/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: redis


### PR DESCRIPTION
Resolves #158  Increased the pod replica count for both the confixa-argocd and confixa-redis services by 3. This was achieved by editing the 'values.yaml' files for each chart, setting the 'replicaCount' value from 4 to 7 for confixa-argocd and from 4 to 7 for confixa-redis, to accommodate the requested increase in pod replicas.