### PR TITLE
Increase the pod replica for every service by 3.

### DIFF
--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -1,47 +1,20 @@
-# Default values for helm-guestbook.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
-
+replicaCount: 4
 image:
   repository: gcr.io/heptio-images/ks-guestbook-demo
   tag: 0.1
   pullPolicy: IfNotPresent
-
 containerPort: 80
-
 service:
   type: ClusterIP
   port: 80
-
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   path: /
   hosts:
     - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
-
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/helm/confixa-argocd/values.yaml
+++ b/helm/confixa-argocd/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: argoproj/argocd

--- a/helm/confixa-redis/values.yaml
+++ b/helm/confixa-redis/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: redis


### PR DESCRIPTION
Resolves #160  The replica count for each service has been increased by 3. This change was applied to the 'values.yaml' files for helm-guestbook, confixa-argocd, and confixa-redis charts. The replicaCount value was updated from its original value to the new value reflecting the increase. No files were created or deleted in this process.