### PR TITLE
Increase the pod replica for every service by 3.

### DIFF
--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -1,47 +1,20 @@
-# Default values for helm-guestbook.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
-
+replicaCount: 4
 image:
   repository: gcr.io/heptio-images/ks-guestbook-demo
   tag: 0.1
   pullPolicy: IfNotPresent
-
 containerPort: 80
-
 service:
   type: ClusterIP
   port: 80
-
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   path: /
   hosts:
     - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
-
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/helm/confixa-argocd/values.yaml
+++ b/helm/confixa-argocd/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: argoproj/argocd

--- a/helm/confixa-redis/values.yaml
+++ b/helm/confixa-redis/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: redis


### PR DESCRIPTION
Resolves #162  To increase the pod replica count for every service by 3, the 'values.yaml' files for helm-guestbook, confixa-argocd, and confixa-redis were edited. The 'replicaCount' value in each of these files was increased by 3 from their original values. This change will instruct Kubernetes to deploy more replicas of each pod, enhancing the availability and scalability of the services.