### PR TITLE
Increase the pod replica for every service by 3.

### DIFF
--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -1,8 +1,4 @@
-# Default values for helm-guestbook.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
+replicaCount: 4
 
 image:
   repository: gcr.io/heptio-images/ks-guestbook-demo

--- a/helm/confixa-argocd/values.yaml
+++ b/helm/confixa-argocd/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: argoproj/argocd

--- a/helm/confixa-redis/values.yaml
+++ b/helm/confixa-redis/values.yaml
@@ -3,7 +3,7 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
-  replicaCount: 4
+  replicaCount: 7
 
   image:
     repository: redis


### PR DESCRIPTION
Resolves #207  Increased the pod replica count for each service by 3. The changes were made in the values.yaml files for the helm-guestbook, confixa-argocd, and confixa-redis charts. The replicaCount values were updated from their original values to the new values.